### PR TITLE
Fix build on non-glibc (POSIX) systems

### DIFF
--- a/mapbox-gl-native-lib.pro
+++ b/mapbox-gl-native-lib.pro
@@ -20,7 +20,7 @@ QMAKE_CXXFLAGS += \
     -fvisibility-inlines-hidden \
     -fvisibility=hidden
 
-android|win32|darwin|qnx {
+android|win32|darwin|qnx|posix {
     SOURCES += \
         platform/qt/src/thread.cpp
 } else {


### PR DESCRIPTION
This way non-glibc Linux systems (like Alpine Linux and postmarketOS) can just define `CONFIG+="posix"` and it'll compile using the thread.cpp wrapper.